### PR TITLE
✨ feat: add auto orderable filter, improve throttling/logging, and fix invitation permissions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,8 +115,8 @@ setup, prefer the Docker workflow.
   invitation email with 60s cooldown; returns 429 if within cooldown, 400 if
   expired/accepted, 200 on success
 - Invitations are looked up by PK (`id`), not by `key` (UUID)
-- Invitations list is role-scoped cumulatively: managers see MANAGER+MEMBER,
-  admins see ADMIN+MANAGER+MEMBER, owners see all roles
+- Invitations list is role-scoped: admins see MANAGER+MEMBER,
+  owners see all roles (OWNER+ADMIN+MANAGER+MEMBER)
 - `StoredFile.file_url` provides absolute download URLs using `SELF_URL`
 
 Preserve this domain model when adding or changing behavior. Permission changes

--- a/apps/accounts/mixins/views.py
+++ b/apps/accounts/mixins/views.py
@@ -12,9 +12,9 @@ from apps.generics.serializers.choices import ChoiceSerializer
 class ModelViewSetMetaclass(type):
     def __new__(cls, name, bases, attrs):
         klass = super().__new__(cls, name, bases, attrs)
-        if not attrs.get('auto_orderable_filter', False):
+        if not getattr(klass, 'auto_orderable_filter', False):
             return klass
-        http_method_names = attrs.get('http_method_names', [])
+        http_method_names = getattr(klass, 'http_method_names', [])
         if http_method_names and 'get' not in http_method_names:
             return klass
         if not cls._get_filterset_class(klass=klass):

--- a/apps/accounts/mixins/views.py
+++ b/apps/accounts/mixins/views.py
@@ -1,12 +1,72 @@
 from django.db.models.expressions import Combinable, F
+from django_filters.rest_framework import filters, filterset
+from rest_framework import serializers
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
 from apps.accounts.mixins.requests import OrganizationScopedRequestMixin
+from apps.generics.mixins.serializers import ModelSerializerFieldsMixin
 from apps.generics.serializers.choices import ChoiceSerializer
 
 
-class ModelViewSetMixin(OrganizationScopedRequestMixin):
+class ModelViewSetMetaclass(type):
+    def __new__(cls, name, bases, attrs):
+        klass = super().__new__(cls, name, bases, attrs)
+        if not attrs.get('auto_orderable_filter', False):
+            return klass
+        http_method_names = attrs.get('http_method_names', [])
+        if http_method_names and 'get' not in http_method_names:
+            return klass
+        if not cls._get_filterset_class(klass=klass):
+            return klass
+        klass.filterset_class = cls._orderable_filter_factory(klass=klass)
+        return klass
+
+    @classmethod
+    def _get_filterset_class(cls, klass) -> type[filterset.FilterSet] | None:
+        view_obj = klass()
+        filterset_class = getattr(view_obj, 'filterset_class', None)
+        if not filterset_class or not issubclass(filterset_class, filterset.FilterSet):
+            return None
+        return filterset_class
+
+    @classmethod
+    def _get_list_serializer_class(cls, klass: type) -> type[serializers.Serializer]:
+        view_obj = klass()
+        view_obj.action = 'list'
+        return view_obj.get_serializer_class()
+
+    @classmethod
+    def _orderable_filter_factory(cls, klass: type) -> type[filterset.FilterSet]:
+        filterset_class: type[filterset.FilterSet] = cls._get_filterset_class(  # type: ignore
+            klass=klass
+        )
+        if 'order_by' in filterset_class.declared_filters:
+            return filterset_class
+
+        serializer_class = cls._get_list_serializer_class(klass=klass)
+        if not issubclass(serializer_class, ModelSerializerFieldsMixin):
+            serializer_class = type(
+                f'Orderable{serializer_class.__name__}',
+                (ModelSerializerFieldsMixin, serializer_class),
+                {},
+            )
+
+        return type(  # type: ignore
+            f'Orderable{filterset_class.__name__}',
+            (filterset_class,),
+            {
+                'order_by': filters.OrderingFilter(
+                    choices=serializer_class.orderable_fields_choices
+                ),
+            },
+        )
+
+
+class ModelViewSetMixin(
+    OrganizationScopedRequestMixin,
+    metaclass=ModelViewSetMetaclass,
+):
     """Mixin for views to add user, member, and organization properties."""
 
     def perform_destroy(self, instance):

--- a/apps/accounts/permissions/invitation.py
+++ b/apps/accounts/permissions/invitation.py
@@ -17,13 +17,7 @@ class InvitationPermission(OrganizationScopedPermission):
 
         if not (auth_member := get_member(request)):
             return False
-        return (
-            obj.role == MemberRoleChoices.OWNER
-            and auth_member.has_owner_permission
-            or obj.role == MemberRoleChoices.ADMIN
+        return auth_member.has_owner_permission or (
+            obj.role in [MemberRoleChoices.MANAGER, MemberRoleChoices.MEMBER]
             and auth_member.has_admin_permission
-            or (
-                obj.role in [MemberRoleChoices.MANAGER, MemberRoleChoices.MEMBER]
-                and auth_member.has_manager_permission
-            )
         )

--- a/apps/accounts/tests/test_invitations/test_filter.py
+++ b/apps/accounts/tests/test_invitations/test_filter.py
@@ -119,3 +119,55 @@ class InvitationFilterTestCase(APITestCaseMixin, APITestCase):
         )
         self.assertEqual(response.status_code, http_status.HTTP_200_OK)
         self.assertEqual(response.data['count'], 1)
+
+    def test_filter_order_by_email_ascending(self):
+        self._create_invitation(email='alice@example.com')
+        self._create_invitation(email='bob@example.com')
+        response = self.client.get(self.list_url, {'order_by': 'email'})
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        emails = [r['email'] for r in response.data['results']]
+        self.assertEqual(emails, sorted(emails))
+
+    def test_filter_order_by_email_descending(self):
+        self._create_invitation(email='alice@example.com')
+        self._create_invitation(email='bob@example.com')
+        response = self.client.get(self.list_url, {'order_by': '-email'})
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        emails = [r['email'] for r in response.data['results']]
+        self.assertEqual(emails, sorted(emails, reverse=True))
+
+    def test_filter_order_by_expired_at_ascending(self):
+        now = timezone.now()
+        self._create_invitation(expired_at=now + timedelta(days=10))
+        self._create_invitation(expired_at=now + timedelta(days=1))
+        response = self.client.get(self.list_url, {'order_by': 'expired_at'})
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        expired_ats = [r['expired_at'] for r in response.data['results']]
+        self.assertEqual(expired_ats, sorted(expired_ats))
+
+    def test_filter_order_by_expired_at_descending(self):
+        now = timezone.now()
+        self._create_invitation(expired_at=now + timedelta(days=1))
+        self._create_invitation(expired_at=now + timedelta(days=10))
+        response = self.client.get(self.list_url, {'order_by': '-expired_at'})
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        expired_ats = [r['expired_at'] for r in response.data['results']]
+        self.assertEqual(expired_ats, sorted(expired_ats, reverse=True))
+
+    def test_filter_order_by_invalid_field(self):
+        self._create_invitation()
+        response = self.client.get(self.list_url, {'order_by': 'nonexistent'})
+        self.assertEqual(response.status_code, http_status.HTTP_400_BAD_REQUEST)
+
+    def test_filter_order_by_with_role_filter(self):
+        self._create_invitation(role=MemberRoleChoices.ADMIN, email='admin@example.com')
+        self._create_invitation(
+            role=MemberRoleChoices.MEMBER, email='member@example.com'
+        )
+        response = self.client.get(
+            self.list_url,
+            {'order_by': 'email', 'role': MemberRoleChoices.ADMIN},
+        )
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        for r in response.data['results']:
+            self.assertEqual(r['role'], MemberRoleChoices.ADMIN)

--- a/apps/accounts/tests/test_invitations/test_permission.py
+++ b/apps/accounts/tests/test_invitations/test_permission.py
@@ -204,7 +204,7 @@ class InvitationPermissionTestCase(APITestCaseMixin, APITestCase):
         response = self.client.post(self.list_url, data=payload, format='json')
         self.assertEqual(response.status_code, http_status.HTTP_400_BAD_REQUEST)
 
-    def test_admin_can_retrieve_admin_invite(self):
+    def test_not_permission_admin_retrieve_admin_invite(self):
         invite = self._create_invitation(role=MemberRoleChoices.ADMIN)
         admin = MemberFactory(
             organization=self.organization,
@@ -213,7 +213,7 @@ class InvitationPermissionTestCase(APITestCaseMixin, APITestCase):
         self.client.force_authenticate(member=admin)
         url = self._detail_url(invite)
         response = self.client.get(url)
-        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        self.assertEqual(response.status_code, http_status.HTTP_404_NOT_FOUND)
 
     def test_admin_can_retrieve_manager_invite(self):
         invite = self._create_invitation(role=MemberRoleChoices.MANAGER)

--- a/apps/accounts/tests/test_members/test_filter.py
+++ b/apps/accounts/tests/test_members/test_filter.py
@@ -84,3 +84,40 @@ class MemberFilterTestCase(APITestCaseMixin, APITestCase):
         response = self.client.get(self.list_url, {'is_active': False})
         self.assertEqual(response.status_code, http_status.HTTP_200_OK)
         self.assertEqual(response.data['count'], 0)
+
+    def test_filter_order_by_nickname_ascending(self):
+        response = self.client.get(self.list_url, {'order_by': 'nickname'})
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        nicknames = [r['nickname'] for r in response.data['results']]
+        self.assertEqual(nicknames, sorted(nicknames))
+
+    def test_filter_order_by_nickname_descending(self):
+        response = self.client.get(self.list_url, {'order_by': '-nickname'})
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        nicknames = [r['nickname'] for r in response.data['results']]
+        self.assertEqual(nicknames, sorted(nicknames, reverse=True))
+
+    def test_filter_order_by_created_at_ascending(self):
+        response = self.client.get(self.list_url, {'order_by': 'created_at'})
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        created_at = [r['created_at'] for r in response.data['results']]
+        self.assertEqual(created_at, sorted(created_at))
+
+    def test_filter_order_by_created_at_descending(self):
+        response = self.client.get(self.list_url, {'order_by': '-created_at'})
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        created_at = [r['created_at'] for r in response.data['results']]
+        self.assertEqual(created_at, sorted(created_at, reverse=True))
+
+    def test_filter_order_by_invalid_field(self):
+        response = self.client.get(self.list_url, {'order_by': 'nonexistent_field'})
+        self.assertEqual(response.status_code, http_status.HTTP_400_BAD_REQUEST)
+
+    def test_filter_order_by_with_other_filter(self):
+        response = self.client.get(
+            self.list_url,
+            {'order_by': 'nickname', 'role': MemberRoleChoices.MEMBER},
+        )
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        for r in response.data['results']:
+            self.assertEqual(r['role'], MemberRoleChoices.MEMBER)

--- a/apps/accounts/tests/test_organization_images/test_filter.py
+++ b/apps/accounts/tests/test_organization_images/test_filter.py
@@ -73,3 +73,28 @@ class OrganizationImageFilterTestCase(APITestCaseMixin, APITestCase):
         )
         self.assertEqual(response.status_code, http_status.HTTP_200_OK)
         self.assertEqual(response.data['count'], 1)
+
+    def test_filter_order_by_image_type_ascending(self):
+        response = self.client.get(self.list_url, {'order_by': 'image_type'})
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        image_types = [r['image_type'] for r in response.data['results']]
+        self.assertEqual(image_types, sorted(image_types))
+
+    def test_filter_order_by_image_type_descending(self):
+        response = self.client.get(self.list_url, {'order_by': '-image_type'})
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        image_types = [r['image_type'] for r in response.data['results']]
+        self.assertEqual(image_types, sorted(image_types, reverse=True))
+
+    def test_filter_order_by_invalid_field(self):
+        response = self.client.get(self.list_url, {'order_by': 'bogus'})
+        self.assertEqual(response.status_code, http_status.HTTP_400_BAD_REQUEST)
+
+    def test_filter_order_by_with_image_type_filter(self):
+        response = self.client.get(
+            self.list_url,
+            {'order_by': 'image_type', 'image_type': OrganizationImageTypeChoices.LOGO},
+        )
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        for r in response.data['results']:
+            self.assertEqual(r['image_type'], OrganizationImageTypeChoices.LOGO)

--- a/apps/accounts/tests/test_organization_profiles/test_filter.py
+++ b/apps/accounts/tests/test_organization_profiles/test_filter.py
@@ -44,3 +44,40 @@ class OrganizationProfileFilterTestCase(APITestCaseMixin, APITestCase):
         )
         self.assertEqual(response.status_code, http_status.HTTP_200_OK)
         self.assertEqual(response.data['count'], 1)
+
+    def test_filter_order_by_website_ascending(self):
+        response = self.client.get(self.list_url, {'order_by': 'website'})
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        websites = [r['website'] for r in response.data['results']]
+        self.assertEqual(websites, sorted(websites))
+
+    def test_filter_order_by_website_descending(self):
+        response = self.client.get(self.list_url, {'order_by': '-website'})
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        websites = [r['website'] for r in response.data['results']]
+        self.assertEqual(websites, sorted(websites, reverse=True))
+
+    def test_filter_order_by_description_ascending(self):
+        response = self.client.get(self.list_url, {'order_by': 'description'})
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        descriptions = [r['description'] for r in response.data['results']]
+        self.assertEqual(descriptions, sorted(descriptions))
+
+    def test_filter_order_by_description_descending(self):
+        response = self.client.get(self.list_url, {'order_by': '-description'})
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        descriptions = [r['description'] for r in response.data['results']]
+        self.assertEqual(descriptions, sorted(descriptions, reverse=True))
+
+    def test_filter_order_by_invalid_field(self):
+        response = self.client.get(self.list_url, {'order_by': 'bogus'})
+        self.assertEqual(response.status_code, http_status.HTTP_400_BAD_REQUEST)
+
+    def test_filter_order_by_with_website_filter(self):
+        response = self.client.get(
+            self.list_url,
+            {'order_by': 'description', 'website__icontains': 'example'},
+        )
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        for r in response.data['results']:
+            self.assertIn('example', r['website'])

--- a/apps/accounts/tests/test_organizations/test_filter.py
+++ b/apps/accounts/tests/test_organizations/test_filter.py
@@ -62,3 +62,38 @@ class OrganizationFilterTestCase(APITestCaseMixin, APITestCase):
         response = self.client.get(self.list_url, {'my_organizations': 'true'})
         self.assertEqual(response.status_code, http_status.HTTP_200_OK)
         self.assertEqual(response.data['count'], 4)
+
+    def test_filter_order_by_name_ascending(self):
+        response = self.client.get(self.list_url, {'order_by': 'name'})
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        names = [r['name'] for r in response.data['results']]
+        self.assertEqual(names, sorted(names))
+
+    def test_filter_order_by_name_descending(self):
+        response = self.client.get(self.list_url, {'order_by': '-name'})
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        names = [r['name'] for r in response.data['results']]
+        self.assertEqual(names, sorted(names, reverse=True))
+
+    def test_filter_order_by_slug_ascending(self):
+        response = self.client.get(self.list_url, {'order_by': 'slug'})
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        slugs = [r['slug'] for r in response.data['results']]
+        self.assertEqual(slugs, sorted(slugs))
+
+    def test_filter_order_by_slug_descending(self):
+        response = self.client.get(self.list_url, {'order_by': '-slug'})
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        slugs = [r['slug'] for r in response.data['results']]
+        self.assertEqual(slugs, sorted(slugs, reverse=True))
+
+    def test_filter_order_by_invalid_field(self):
+        response = self.client.get(self.list_url, {'order_by': 'invalid'})
+        self.assertEqual(response.status_code, http_status.HTTP_400_BAD_REQUEST)
+
+    def test_filter_order_by_with_name_filter(self):
+        response = self.client.get(
+            self.list_url,
+            {'order_by': 'slug', 'name__icontains': 'corp'},
+        )
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)

--- a/apps/accounts/tests/test_stored_files/test_filter.py
+++ b/apps/accounts/tests/test_stored_files/test_filter.py
@@ -57,3 +57,40 @@ class StoredFileFilterTestCase(APITestCaseMixin, APITestCase):
         )
         self.assertEqual(response.status_code, http_status.HTTP_200_OK)
         self.assertEqual(response.data['count'], 3)
+
+    def test_filter_order_by_name_ascending(self):
+        response = self.client.get(self.list_url, {'order_by': 'name'})
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        names = [r['name'] for r in response.data['results']]
+        self.assertEqual(names, sorted(names))
+
+    def test_filter_order_by_name_descending(self):
+        response = self.client.get(self.list_url, {'order_by': '-name'})
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        names = [r['name'] for r in response.data['results']]
+        self.assertEqual(names, sorted(names, reverse=True))
+
+    def test_filter_order_by_size_ascending(self):
+        response = self.client.get(self.list_url, {'order_by': 'size'})
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        sizes = [r['size'] for r in response.data['results']]
+        self.assertEqual(sizes, sorted(sizes))
+
+    def test_filter_order_by_size_descending(self):
+        response = self.client.get(self.list_url, {'order_by': '-size'})
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        sizes = [r['size'] for r in response.data['results']]
+        self.assertEqual(sizes, sorted(sizes, reverse=True))
+
+    def test_filter_order_by_invalid_field(self):
+        response = self.client.get(self.list_url, {'order_by': 'bogus'})
+        self.assertEqual(response.status_code, http_status.HTTP_400_BAD_REQUEST)
+
+    def test_filter_order_by_with_content_type_filter(self):
+        response = self.client.get(
+            self.list_url,
+            {'order_by': 'name', 'content_type': 'text/plain'},
+        )
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        for r in response.data['results']:
+            self.assertEqual(r['content_type'], 'text/plain')

--- a/apps/accounts/tests/test_viewset_metaclass.py
+++ b/apps/accounts/tests/test_viewset_metaclass.py
@@ -1,0 +1,110 @@
+from django.test import SimpleTestCase
+from django_filters.rest_framework import filters, filterset
+from rest_framework import serializers
+
+from apps.accounts.mixins.views import ModelViewSetMetaclass
+from apps.generics.mixins.serializers import ModelSerializerFieldsMixin
+
+
+class _BaseFilterSet(filterset.FilterSet):
+    name = filters.CharFilter()
+
+
+class _OrderedFilterSet(_BaseFilterSet):
+    order_by = filters.OrderingFilter()
+
+
+class _SimpleSer(serializers.Serializer):
+    class Meta:
+        fields = ['name']
+
+
+class _SerWithMixin(ModelSerializerFieldsMixin, serializers.Serializer):
+    class Meta:
+        fields = ['name']
+
+
+class OrderableFilterMetaclassTestCase(SimpleTestCase):
+    def test_adds_ordering_filter(self):
+        class TV(metaclass=ModelViewSetMetaclass):
+            filterset_class = _BaseFilterSet
+            http_method_names = ['get']
+            auto_orderable_filter = True
+            serializer_class = _SimpleSer
+
+            def get_serializer_class(self):
+                return self.serializer_class
+
+        self.assertIn('order_by', TV.filterset_class.declared_filters)
+
+    def test_skipped_when_flag_false(self):
+        class TV(metaclass=ModelViewSetMetaclass):
+            filterset_class = _BaseFilterSet
+            http_method_names = ['get']
+            serializer_class = _SimpleSer
+
+            def get_serializer_class(self):
+                return self.serializer_class
+
+        self.assertIs(TV.filterset_class, _BaseFilterSet)
+
+    def test_skipped_when_no_get_method(self):
+        class TV(metaclass=ModelViewSetMetaclass):
+            filterset_class = _BaseFilterSet
+            http_method_names = ['post', 'put']
+            auto_orderable_filter = True
+            serializer_class = _SimpleSer
+
+            def get_serializer_class(self):
+                return self.serializer_class
+
+        self.assertIs(TV.filterset_class, _BaseFilterSet)
+
+    def test_skipped_when_no_filterset_class(self):
+        class TV(metaclass=ModelViewSetMetaclass):
+            http_method_names = ['get']
+            auto_orderable_filter = True
+            serializer_class = _SimpleSer
+
+            def get_serializer_class(self):
+                return self.serializer_class
+
+        self.assertFalse(hasattr(TV, 'filterset_class'))
+
+    def test_respects_existing_order_by(self):
+        class TV(metaclass=ModelViewSetMetaclass):
+            filterset_class = _OrderedFilterSet
+            http_method_names = ['get']
+            auto_orderable_filter = True
+            serializer_class = _SimpleSer
+
+            def get_serializer_class(self):
+                return self.serializer_class
+
+        self.assertIs(TV.filterset_class, _OrderedFilterSet)
+
+    def test_wraps_serializer_with_mixin_if_missing(self):
+        class TV(metaclass=ModelViewSetMetaclass):
+            filterset_class = _BaseFilterSet
+            http_method_names = ['get']
+            auto_orderable_filter = True
+            serializer_class = _SimpleSer
+
+            def get_serializer_class(self):
+                return self.serializer_class
+
+        order_by = TV.filterset_class.declared_filters['order_by']
+        self.assertIsNotNone(order_by)
+
+    def test_does_not_wrap_if_mixin_present(self):
+        class TV(metaclass=ModelViewSetMetaclass):
+            filterset_class = _BaseFilterSet
+            http_method_names = ['get']
+            auto_orderable_filter = True
+            serializer_class = _SerWithMixin
+
+            def get_serializer_class(self):
+                return self.serializer_class
+
+        order_by = TV.filterset_class.declared_filters['order_by']
+        self.assertIsInstance(order_by, filters.OrderingFilter)

--- a/apps/accounts/views/files.py
+++ b/apps/accounts/views/files.py
@@ -76,6 +76,7 @@ class StoredFileViewSet(ModelViewSetMixin, viewsets.ModelViewSet):
     lookup_field = 'uuid'
     label_expression = StoredFile.label_expression()
     queryset = StoredFile.objects.all()
+    auto_orderable_filter = True
 
     def get_queryset(self):
         queryset = super().get_queryset()

--- a/apps/accounts/views/invitations.py
+++ b/apps/accounts/views/invitations.py
@@ -119,6 +119,7 @@ class InvitationViewSet(
     filterset_class = InvitationFilter
     filter_backends = [backends.DjangoFilterBackend]
     label_expression = 'email'
+    auto_orderable_filter = True
 
     def get_queryset(self):
         queryset = super().get_queryset()

--- a/apps/accounts/views/invitations.py
+++ b/apps/accounts/views/invitations.py
@@ -126,12 +126,10 @@ class InvitationViewSet(
         if not (auth_member := self.auth_member):
             return queryset.none()
         role_list = []
-        if auth_member.has_manager_permission:
-            role_list.extend([MemberRoleChoices.MANAGER, MemberRoleChoices.MEMBER])
         if auth_member.has_admin_permission:
-            role_list.append(MemberRoleChoices.ADMIN)
+            role_list.extend([MemberRoleChoices.MANAGER, MemberRoleChoices.MEMBER])
         if auth_member.has_owner_permission:
-            role_list.append(MemberRoleChoices.OWNER)
+            role_list.extend([MemberRoleChoices.OWNER, MemberRoleChoices.ADMIN])
         queryset = queryset.filter(role__in=role_list)
         return queryset
 

--- a/apps/accounts/views/members.py
+++ b/apps/accounts/views/members.py
@@ -132,6 +132,7 @@ class MemberViewSet(
     filterset_class = MemberFilter
     filter_backends = [backends.DjangoFilterBackend]
     label_expression = Member.label_expression()
+    auto_orderable_filter = True
 
     base_filters = {'is_active': True}
 

--- a/apps/accounts/views/organization_images.py
+++ b/apps/accounts/views/organization_images.py
@@ -22,3 +22,4 @@ class OrganizationImageViewSet(ModelViewSetMixin, viewsets.ModelViewSet):
     filter_backends = [backends.DjangoFilterBackend]
     label_expression = OrganizationImage.label_expression()
     parser_classes = [MultiPartParser, FormParser]
+    auto_orderable_filter = True

--- a/apps/accounts/views/organization_profiles.py
+++ b/apps/accounts/views/organization_profiles.py
@@ -26,3 +26,4 @@ class OrganizationProfileViewSet(
     filterset_class = OrganizationProfileFilter
     filter_backends = [backends.DjangoFilterBackend]
     label_expression = 'organization__name'
+    auto_orderable_filter = True

--- a/apps/accounts/views/organizations.py
+++ b/apps/accounts/views/organizations.py
@@ -101,6 +101,7 @@ class OrganizationViewSet(ModelViewSetMixin, viewsets.ModelViewSet):
     filterset_class = OrganizationFilter
     filter_backends = [backends.DjangoFilterBackend]
     label_expression = 'name'
+    auto_orderable_filter = True
 
     def get_queryset(self):
         """

--- a/apps/generics/choices.py
+++ b/apps/generics/choices.py
@@ -1,0 +1,13 @@
+from django.db import models
+from django.utils.translation import gettext_lazy as _
+
+
+class ErrorCode(models.TextChoices):
+    AUTHENTICATION_ERROR = 'AUTHENTICATION_ERROR', _('Authentication error')
+    PERMISSION_DENIED = 'PERMISSION_DENIED', _('Permission denied')
+    NOT_FOUND = 'NOT_FOUND', _('Not found')
+    METHOD_NOT_ALLOWED = 'METHOD_NOT_ALLOWED', _('Method not allowed')
+    NOT_ACCEPTABLE = 'NOT_ACCEPTABLE', _('Not acceptable')
+    THROTTLED = 'THROTTLED', _('Throttled')
+    VALIDATION_ERROR = 'VALIDATION_ERROR', _('Validation error')
+    INTERNAL_ERROR = 'INTERNAL_ERROR', _('Internal error')

--- a/apps/generics/exceptions.py
+++ b/apps/generics/exceptions.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.http import Http404
 from django.utils.translation import gettext_lazy as _
 from rest_framework import exceptions, status
@@ -9,6 +11,8 @@ from rest_framework.exceptions import (
 )
 from rest_framework.response import Response
 from rest_framework.views import exception_handler
+
+logger = logging.getLogger(__name__)
 
 
 def _get_error_code(exc: APIException) -> str:
@@ -66,6 +70,8 @@ def _get_error_details(exc: APIException) -> dict | None:
 
 def custom_exception_handler(exc, context):
     response = exception_handler(exc, context)
+
+    logger.exception('Internal server error: %s', exc)
 
     if response is None:
         return Response(

--- a/apps/generics/exceptions.py
+++ b/apps/generics/exceptions.py
@@ -12,29 +12,31 @@ from rest_framework.exceptions import (
 from rest_framework.response import Response
 from rest_framework.views import exception_handler
 
+from apps.generics.choices import ErrorCode
+
 logger = logging.getLogger(__name__)
 
 
-def _get_error_code(exc: APIException) -> str:
+def _get_error_code(exc: APIException) -> ErrorCode:
     mapping = {
-        AuthenticationFailed: 'AUTHENTICATION_ERROR',
-        NotAuthenticated: 'AUTHENTICATION_ERROR',
-        PermissionDenied: 'PERMISSION_DENIED',
-        Http404: 'NOT_FOUND',
-        exceptions.MethodNotAllowed: 'METHOD_NOT_ALLOWED',
-        exceptions.NotAcceptable: 'NOT_ACCEPTABLE',
-        exceptions.Throttled: 'THROTTLED',
+        AuthenticationFailed: ErrorCode.AUTHENTICATION_ERROR,
+        NotAuthenticated: ErrorCode.AUTHENTICATION_ERROR,
+        PermissionDenied: ErrorCode.PERMISSION_DENIED,
+        Http404: ErrorCode.NOT_FOUND,
+        exceptions.MethodNotAllowed: ErrorCode.METHOD_NOT_ALLOWED,
+        exceptions.NotAcceptable: ErrorCode.NOT_ACCEPTABLE,
+        exceptions.Throttled: ErrorCode.THROTTLED,
     }
     for exc_type, code in mapping.items():
         if isinstance(exc, exc_type):
             return code
     if isinstance(exc, exceptions.ValidationError):
-        return 'VALIDATION_ERROR'
-    return 'INTERNAL_ERROR'
+        return ErrorCode.VALIDATION_ERROR
+    return ErrorCode.INTERNAL_ERROR
 
 
-def _get_error_message(exc: APIException, code: str) -> str:
-    if code == 'VALIDATION_ERROR':
+def _get_error_message(exc: APIException, code: ErrorCode) -> str:
+    if code == ErrorCode.VALIDATION_ERROR:
         return _('One or more fields are invalid.')
     if isinstance(exc, APIException) and hasattr(exc, 'detail'):
         detail = exc.detail
@@ -71,13 +73,12 @@ def _get_error_details(exc: APIException) -> dict | None:
 def custom_exception_handler(exc, context):
     response = exception_handler(exc, context)
 
-    logger.exception('Internal server error: %s', exc)
-
     if response is None:
+        logger.exception('Internal server error: %s', exc)
         return Response(
             {
                 'error': {
-                    'code': 'INTERNAL_ERROR',
+                    'code': ErrorCode.INTERNAL_ERROR,
                     'message': _('An unexpected error occurred.'),
                     'details': None,
                 },
@@ -85,7 +86,8 @@ def custom_exception_handler(exc, context):
             status=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
 
-    code = _get_error_code(exc)
+    if (code := _get_error_code(exc)) == ErrorCode.INTERNAL_ERROR:
+        logger.exception('Internal server error: %s', exc)
     message = _get_error_message(exc, code)
     details = _get_error_details(exc)
 

--- a/apps/generics/mixins/serializers.py
+++ b/apps/generics/mixins/serializers.py
@@ -29,7 +29,7 @@ class ModelSerializerFieldsMixin(serializers.ModelSerializer):
 
     @classmethod
     def _get_verbose_name_field(cls, field_name: str) -> str | None:
-        verbose_name = str(_(pretty_name(field_name)))
+        verbose_name = _(pretty_name(field_name))
         if not (model_class := getattr(cls.Meta, 'model', None)):
             return verbose_name
         opts = model_class._meta

--- a/apps/generics/mixins/serializers.py
+++ b/apps/generics/mixins/serializers.py
@@ -1,0 +1,79 @@
+import copy
+
+from django.core.exceptions import FieldDoesNotExist
+from django.db.models import ForeignObjectRel
+from django.forms.utils import pretty_name
+from django.utils.functional import classproperty
+from django.utils.text import capfirst
+from django.utils.translation import gettext_lazy as _
+from rest_framework import serializers
+from rest_framework.utils import model_meta
+
+
+class ModelSerializerFieldsMixin(serializers.ModelSerializer):
+    @classproperty
+    def all_model_fields(cls) -> list[str]:
+        model = getattr(cls.Meta, 'model', None)
+        declared_fields = copy.deepcopy(cls._declared_fields)
+
+        model_info = model_meta.get_field_info(model)
+        fields = (
+            [model_info.pk.name]
+            + list(declared_fields)
+            + list(model_info.fields)
+            + list(model_info.forward_relations)
+        )
+        if exclude := getattr(cls.Meta, 'exclude', None):
+            fields = [f for f in fields if f not in exclude]
+        return fields
+
+    @classmethod
+    def _get_verbose_name_field(cls, field_name: str) -> str | None:
+        verbose_name = str(_(pretty_name(field_name)))
+        if not (model_class := getattr(cls.Meta, 'model', None)):
+            return verbose_name
+        opts = model_class._meta
+        field = opts.get_field(field_name)
+        if isinstance(field, ForeignObjectRel):
+            return None
+        if field.verbose_name:
+            return capfirst(field.verbose_name)
+        return verbose_name
+
+    @classproperty
+    def orderable_fields_choices(cls) -> list[tuple[str, str]]:
+        fields = getattr(cls.Meta, 'fields', None)
+        if fields is None or fields == serializers.ALL_FIELDS:
+            fields = cls.all_model_fields
+
+        declared_fields = copy.deepcopy(cls._declared_fields)
+        declared_fields_exclude = []
+        for field_name, serializer_field in declared_fields.items():
+            if (
+                isinstance(
+                    serializer_field,
+                    (serializers.BaseSerializer, serializers.SerializerMethodField),
+                )
+                or serializer_field.write_only
+            ):
+                declared_fields_exclude.append(field_name)
+
+        choices = []
+        for field in fields:
+            if field in declared_fields_exclude:
+                continue
+            try:
+                get_verbose_name = cls._get_verbose_name_field(field)
+            except FieldDoesNotExist:
+                continue
+            if get_verbose_name:
+                choices.append((field, get_verbose_name))
+        ascending = sorted(choices, key=lambda x: x[1])
+        descending_label = _('Descending %(label)s')
+        descending = [
+            (f'-{field}', descending_label % {'label': label})
+            for field, label in ascending
+        ]
+        return [
+            val for pair in zip(ascending, descending, strict=False) for val in pair
+        ]

--- a/apps/generics/tests/test_exceptions.py
+++ b/apps/generics/tests/test_exceptions.py
@@ -11,6 +11,7 @@ from apps.accounts.choices import MemberRoleChoices
 from apps.accounts.factories.members import MemberFactory
 from apps.accounts.factories.users import UserFactory
 from apps.accounts.tests.mixins import APITestCaseMixin
+from apps.generics.choices import ErrorCode
 from apps.generics.exceptions import (
     _get_error_code,
     _get_error_details,
@@ -33,84 +34,86 @@ class ExceptionHandlerUnitTestCase(SimpleTestCase):
         from rest_framework.exceptions import AuthenticationFailed
 
         code = _get_error_code(AuthenticationFailed())
-        self.assertEqual(code, 'AUTHENTICATION_ERROR')
+        self.assertEqual(code, ErrorCode.AUTHENTICATION_ERROR)
 
     def test_get_error_code_not_authenticated(self):
         from rest_framework.exceptions import NotAuthenticated
 
         code = _get_error_code(NotAuthenticated())
-        self.assertEqual(code, 'AUTHENTICATION_ERROR')
+        self.assertEqual(code, ErrorCode.AUTHENTICATION_ERROR)
 
     def test_get_error_code_permission_denied(self):
         from rest_framework.exceptions import PermissionDenied
 
         code = _get_error_code(PermissionDenied())
-        self.assertEqual(code, 'PERMISSION_DENIED')
+        self.assertEqual(code, ErrorCode.PERMISSION_DENIED)
 
     def test_get_error_code_http404(self):
         from django.http import Http404
 
         code = _get_error_code(Http404())
-        self.assertEqual(code, 'NOT_FOUND')
+        self.assertEqual(code, ErrorCode.NOT_FOUND)
 
     def test_get_error_code_method_not_allowed(self):
         from rest_framework.exceptions import MethodNotAllowed
 
         code = _get_error_code(MethodNotAllowed('GET'))
-        self.assertEqual(code, 'METHOD_NOT_ALLOWED')
+        self.assertEqual(code, ErrorCode.METHOD_NOT_ALLOWED)
 
     def test_get_error_code_not_acceptable(self):
         from rest_framework.exceptions import NotAcceptable
 
         code = _get_error_code(NotAcceptable())
-        self.assertEqual(code, 'NOT_ACCEPTABLE')
+        self.assertEqual(code, ErrorCode.NOT_ACCEPTABLE)
 
     def test_get_error_code_throttled(self):
         from rest_framework.exceptions import Throttled
 
         code = _get_error_code(Throttled())
-        self.assertEqual(code, 'THROTTLED')
+        self.assertEqual(code, ErrorCode.THROTTLED)
 
     def test_get_error_code_validation_error(self):
         from rest_framework.exceptions import ValidationError
 
         code = _get_error_code(ValidationError({'field': ['error']}))
-        self.assertEqual(code, 'VALIDATION_ERROR')
+        self.assertEqual(code, ErrorCode.VALIDATION_ERROR)
 
     def test_get_error_code_unknown_exception(self):
         code = _get_error_code(ValueError('something'))
-        self.assertEqual(code, 'INTERNAL_ERROR')
+        self.assertEqual(code, ErrorCode.INTERNAL_ERROR)
 
     def test_get_error_message_validation(self):
         from rest_framework.exceptions import ValidationError
 
         exc = ValidationError({'field': ['error']})
-        msg = _get_error_message(exc, 'VALIDATION_ERROR')
+        msg = _get_error_message(exc, ErrorCode.VALIDATION_ERROR)
         self.assertEqual(msg, 'One or more fields are invalid.')
 
     def test_get_error_message_from_string_detail(self):
         from rest_framework.exceptions import PermissionDenied
 
         exc = PermissionDenied('Custom error message')
-        msg = _get_error_message(exc, 'PERMISSION_DENIED')
+        msg = _get_error_message(exc, ErrorCode.PERMISSION_DENIED)
         self.assertEqual(msg, 'Custom error message')
 
     def test_get_error_message_from_dict_detail(self):
         from rest_framework.exceptions import PermissionDenied
 
         exc = PermissionDenied({'field1': ['First error'], 'field2': ['Second']})
-        msg = _get_error_message(exc, 'PERMISSION_DENIED')
+        msg = _get_error_message(exc, ErrorCode.PERMISSION_DENIED)
         self.assertEqual(msg, 'First error')
 
     def test_get_error_message_from_list_detail(self):
         from rest_framework.exceptions import PermissionDenied
 
         exc = PermissionDenied(['First error', 'Second error'])
-        msg = _get_error_message(exc, 'PERMISSION_DENIED')
+        msg = _get_error_message(exc, ErrorCode.PERMISSION_DENIED)
         self.assertEqual(msg, 'First error')
 
     def test_get_error_message_fallback(self):
-        msg = _get_error_message(ValueError('Something broke'), 'INTERNAL_ERROR')
+        msg = _get_error_message(
+            ValueError('Something broke'), ErrorCode.INTERNAL_ERROR
+        )
         self.assertEqual(msg, 'Something broke')
 
     def test_get_error_details_validation_dict(self):
@@ -144,7 +147,7 @@ class ExceptionHandlerIntegrationTestCase(APITestCaseMixin, APITestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn('error', response.data)
-        self.assertEqual(response.data['error']['code'], 'VALIDATION_ERROR')
+        self.assertEqual(response.data['error']['code'], ErrorCode.VALIDATION_ERROR)
         self.assertIsInstance(response.data['error']['details'], dict)
         self.assertIsNotNone(response.data['error']['message'])
 
@@ -152,7 +155,7 @@ class ExceptionHandlerIntegrationTestCase(APITestCaseMixin, APITestCase):
         response = self.client.get(reverse('accounts:members-list'))
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
         self.assertIn('error', response.data)
-        self.assertEqual(response.data['error']['code'], 'AUTHENTICATION_ERROR')
+        self.assertEqual(response.data['error']['code'], ErrorCode.AUTHENTICATION_ERROR)
         self.assertIsNone(response.data['error']['details'])
 
     def test_permission_denied_format(self):
@@ -166,7 +169,7 @@ class ExceptionHandlerIntegrationTestCase(APITestCaseMixin, APITestCase):
         response = self.client.get(reverse('accounts:invitations-list'))
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertIn('error', response.data)
-        self.assertEqual(response.data['error']['code'], 'PERMISSION_DENIED')
+        self.assertEqual(response.data['error']['code'], ErrorCode.PERMISSION_DENIED)
         self.assertIsNone(response.data['error']['details'])
 
     def test_not_found_format(self):
@@ -176,7 +179,7 @@ class ExceptionHandlerIntegrationTestCase(APITestCaseMixin, APITestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         self.assertIn('error', response.data)
-        self.assertEqual(response.data['error']['code'], 'NOT_FOUND')
+        self.assertEqual(response.data['error']['code'], ErrorCode.NOT_FOUND)
         self.assertIsNone(response.data['error']['details'])
 
     def test_method_not_allowed_format(self):
@@ -187,7 +190,7 @@ class ExceptionHandlerIntegrationTestCase(APITestCaseMixin, APITestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
         self.assertIn('error', response.data)
-        self.assertEqual(response.data['error']['code'], 'METHOD_NOT_ALLOWED')
+        self.assertEqual(response.data['error']['code'], ErrorCode.METHOD_NOT_ALLOWED)
         self.assertIsNone(response.data['error']['details'])
 
     def test_not_acceptable_format(self):
@@ -198,7 +201,7 @@ class ExceptionHandlerIntegrationTestCase(APITestCaseMixin, APITestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
         self.assertIn('error', response.data)
-        self.assertEqual(response.data['error']['code'], 'NOT_ACCEPTABLE')
+        self.assertEqual(response.data['error']['code'], ErrorCode.NOT_ACCEPTABLE)
         self.assertIsNone(response.data['error']['details'])
 
     @override_settings(
@@ -218,7 +221,7 @@ class ExceptionHandlerIntegrationTestCase(APITestCaseMixin, APITestCase):
             response = self.client.get(url)
             self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
             self.assertIn('error', response.data)
-            self.assertEqual(response.data['error']['code'], 'THROTTLED')
+            self.assertEqual(response.data['error']['code'], ErrorCode.THROTTLED)
             self.assertIsNone(response.data['error']['details'])
         finally:
             SimpleRateThrottle.THROTTLE_RATES = original_rates
@@ -228,7 +231,7 @@ class ExceptionHandlerIntegrationTestCase(APITestCaseMixin, APITestCase):
         response = self.client.get('/trigger-error/')
         self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
         self.assertIn('error', response.data)
-        self.assertEqual(response.data['error']['code'], 'INTERNAL_ERROR')
+        self.assertEqual(response.data['error']['code'], ErrorCode.INTERNAL_ERROR)
         self.assertIsNone(response.data['error']['details'])
 
     def test_details_null_for_non_validation(self):

--- a/apps/generics/tests/test_serializer_mixins.py
+++ b/apps/generics/tests/test_serializer_mixins.py
@@ -1,0 +1,110 @@
+from django.test import SimpleTestCase
+from rest_framework import serializers
+
+from apps.accounts.models.member import Member
+from apps.generics.mixins.serializers import ModelSerializerFieldsMixin
+
+
+class _NestedSerializer(serializers.Serializer):
+    name = serializers.CharField()
+
+
+class OrderableFieldsChoicesTestCase(SimpleTestCase):
+    def test_includes_pk_declared_and_model_fields(self):
+        class TS(ModelSerializerFieldsMixin, serializers.ModelSerializer):
+            class Meta:
+                model = Member
+                fields = '__all__'
+
+        fields = [c[0] for c in TS.orderable_fields_choices]
+        self.assertIn('id', fields)
+        self.assertIn('nickname', fields)
+        self.assertIn('role', fields)
+        self.assertIn('created_at', fields)
+
+    def test_excludes_write_only_fields(self):
+        class TS(ModelSerializerFieldsMixin, serializers.ModelSerializer):
+            secret = serializers.CharField(write_only=True)
+
+            class Meta:
+                model = Member
+                fields = '__all__'
+
+        fields = [c[0] for c in TS.orderable_fields_choices]
+        self.assertNotIn('secret', fields)
+        self.assertIn('nickname', fields)
+
+    def test_excludes_serializer_method_field(self):
+        class TS(ModelSerializerFieldsMixin, serializers.ModelSerializer):
+            computed = serializers.SerializerMethodField()
+
+            class Meta:
+                model = Member
+                fields = '__all__'
+
+        fields = [c[0] for c in TS.orderable_fields_choices]
+        self.assertNotIn('computed', fields)
+
+    def test_excludes_nested_serializers(self):
+        class TS(ModelSerializerFieldsMixin, serializers.ModelSerializer):
+            nested = _NestedSerializer()
+
+            class Meta:
+                model = Member
+                fields = '__all__'
+
+        fields = [c[0] for c in TS.orderable_fields_choices]
+        self.assertNotIn('nested', fields)
+
+    def test_descending_entries_have_minus_prefix(self):
+        class TS(ModelSerializerFieldsMixin, serializers.ModelSerializer):
+            class Meta:
+                model = Member
+                fields = ['nickname', 'role']
+
+        choices = TS.orderable_fields_choices
+        self.assertEqual(choices[0][0], 'nickname')
+        self.assertEqual(choices[1][0], '-nickname')
+        self.assertEqual(choices[2][0], 'role')
+        self.assertEqual(choices[3][0], '-role')
+
+    def test_descending_labels_use_template(self):
+        class TS(ModelSerializerFieldsMixin, serializers.ModelSerializer):
+            class Meta:
+                model = Member
+                fields = ['nickname']
+
+        choices = TS.orderable_fields_choices
+        self.assertEqual(choices[1][1], 'Descending Nickname')
+
+    def test_uses_verbose_name_from_model(self):
+        class TS(ModelSerializerFieldsMixin, serializers.ModelSerializer):
+            class Meta:
+                model = Member
+                fields = ['nickname', 'last_login_at']
+
+        choices = dict(TS.orderable_fields_choices)
+        self.assertEqual(choices['nickname'], 'Nickname')
+        self.assertEqual(choices['last_login_at'], 'Last login at')
+
+    def test_returns_choices_sorted_by_label(self):
+        class TS(ModelSerializerFieldsMixin, serializers.ModelSerializer):
+            class Meta:
+                model = Member
+                fields = ['nickname', 'role', 'id']
+
+        labels = [c[1] for c in TS.orderable_fields_choices if not c[0].startswith('-')]
+        self.assertEqual(labels, sorted(labels))
+
+    def test_skips_reverse_relations(self):
+        class TS(ModelSerializerFieldsMixin, serializers.ModelSerializer):
+            class Meta:
+                model = Member
+                fields = '__all__'
+
+        choices = TS.orderable_fields_choices
+        fields = [c[0] for c in choices if not c[0].startswith('-')]
+        fields_no_prefix = {f.lstrip('-') for f in fields}
+
+        self.assertNotIn('owned_organizations', fields_no_prefix)
+        self.assertNotIn('teams', fields_no_prefix)

--- a/apps/teams/tests/test_team_members/test_filter.py
+++ b/apps/teams/tests/test_team_members/test_filter.py
@@ -40,3 +40,37 @@ class TeamMemberFilterTestCase(APITestCaseMixin, APITestCase):
         response = self.client.get(self.list_url, {'role': TeamMemberRoleChoices.ADMIN})
         self.assertEqual(response.status_code, http_status.HTTP_200_OK)
         self.assertEqual(response.data['count'], 1)
+
+    def test_filter_order_by_role_ascending(self):
+        TeamMemberFactory.create_batch(size=3, organization=self.organization)
+        response = self.client.get(self.list_url, {'order_by': 'role'})
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        roles = [r['role'] for r in response.data['results']]
+        self.assertEqual(roles, sorted(roles))
+
+    def test_filter_order_by_role_descending(self):
+        TeamMemberFactory.create_batch(size=3, organization=self.organization)
+        response = self.client.get(self.list_url, {'order_by': '-role'})
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        roles = [r['role'] for r in response.data['results']]
+        self.assertEqual(roles, sorted(roles, reverse=True))
+
+    def test_filter_order_by_invalid_field(self):
+        TeamMemberFactory(organization=self.organization)
+        response = self.client.get(self.list_url, {'order_by': 'bogus'})
+        self.assertEqual(response.status_code, http_status.HTTP_400_BAD_REQUEST)
+
+    def test_filter_order_by_with_role_filter(self):
+        TeamMemberFactory(
+            organization=self.organization, role=TeamMemberRoleChoices.ADMIN
+        )
+        TeamMemberFactory(
+            organization=self.organization, role=TeamMemberRoleChoices.MEMBER
+        )
+        response = self.client.get(
+            self.list_url,
+            {'order_by': 'role', 'role': TeamMemberRoleChoices.ADMIN},
+        )
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        for r in response.data['results']:
+            self.assertEqual(r['role'], TeamMemberRoleChoices.ADMIN)

--- a/apps/teams/tests/test_teams/test_filter.py
+++ b/apps/teams/tests/test_teams/test_filter.py
@@ -48,3 +48,40 @@ class TeamFilterTestCase(APITestCaseMixin, APITestCase):
         response = self.client.get(self.list_url, {'slug__icontains': 'team'})
         self.assertEqual(response.status_code, http_status.HTTP_200_OK)
         self.assertEqual(response.data['count'], 2)
+
+    def test_filter_order_by_name_ascending(self):
+        response = self.client.get(self.list_url, {'order_by': 'name'})
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        names = [r['name'] for r in response.data['results']]
+        self.assertEqual(names, sorted(names))
+
+    def test_filter_order_by_name_descending(self):
+        response = self.client.get(self.list_url, {'order_by': '-name'})
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        names = [r['name'] for r in response.data['results']]
+        self.assertEqual(names, sorted(names, reverse=True))
+
+    def test_filter_order_by_slug_ascending(self):
+        response = self.client.get(self.list_url, {'order_by': 'slug'})
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        slugs = [r['slug'] for r in response.data['results']]
+        self.assertEqual(slugs, sorted(slugs))
+
+    def test_filter_order_by_slug_descending(self):
+        response = self.client.get(self.list_url, {'order_by': '-slug'})
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        slugs = [r['slug'] for r in response.data['results']]
+        self.assertEqual(slugs, sorted(slugs, reverse=True))
+
+    def test_filter_order_by_invalid_field(self):
+        response = self.client.get(self.list_url, {'order_by': 'bogus'})
+        self.assertEqual(response.status_code, http_status.HTTP_400_BAD_REQUEST)
+
+    def test_filter_order_by_with_name_filter(self):
+        response = self.client.get(
+            self.list_url,
+            {'order_by': 'slug', 'name__icontains': 'team'},
+        )
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        for r in response.data['results']:
+            self.assertIn('team', r['name'].lower())

--- a/apps/teams/views/team_members.py
+++ b/apps/teams/views/team_members.py
@@ -39,6 +39,7 @@ class TeamMemberViewSet(
     filterset_class = TeamMemberFilter
     filter_backends = [backends.DjangoFilterBackend]
     label_expression = TeamMember.label_expression()
+    auto_orderable_filter = True
 
     organization_filter = 'team__organization_id'
     base_filters = {

--- a/apps/teams/views/teams.py
+++ b/apps/teams/views/teams.py
@@ -21,3 +21,4 @@ class TeamViewSet(
     filter_backends = [backends.DjangoFilterBackend]
     base_filters = {'is_active': True}
     label_expression = 'name'
+    auto_orderable_filter = True

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -222,8 +222,8 @@ REST_FRAMEWORK = {
         'rest_framework.throttling.UserRateThrottle',
     ],
     'DEFAULT_THROTTLE_RATES': {
-        'anon': '100/hour',
-        'user': '1000/hour',
+        'anon': '1000/hour',
+        'user': '10000/hour',
     },
     'EXCEPTION_HANDLER': 'apps.generics.exceptions.custom_exception_handler',
 }

--- a/docs/behavioral-patterns.md
+++ b/docs/behavioral-patterns.md
@@ -334,12 +334,10 @@ Each resource defines its own permission strategy by extending `OrganizationScop
   object-level role checks
 - `has_object_permission` checks the invitation's role against the auth member's
   permission level:
-  - OWNER role → requires `has_owner_permission`
-  - ADMIN role → requires `has_admin_permission`
-  - MANAGER or MEMBER role → requires `has_manager_permission`
-- `InvitationViewSet.get_queryset()` applies cumulative role-based filtering:
-  managers see MANAGER+MEMBER, admins see ADMIN+MANAGER+MEMBER, owners see all
-  roles (OWNER+ADMIN+MANAGER+MEMBER)
+  - Owner can access any invitation role
+  - MANAGER or MEMBER role → requires `has_admin_permission`
+- `InvitationViewSet.get_queryset()` applies role-based filtering:
+  admins see MANAGER+MEMBER, owners see all roles (OWNER+ADMIN+MANAGER+MEMBER)
 
 **TeamPermission** (`apps/teams/permissions/team.py`):
 - SAFE methods allowed for all active members

--- a/docs/frontend-integration-guide.md
+++ b/docs/frontend-integration-guide.md
@@ -476,13 +476,13 @@ Email and role are taken from the invitation itself (not from the request body).
 
 | Action | Endpoint | Permission |
 |---|---|---|
-| List | `GET /api/accounts/invitations/` | Role-scoped (manager+ sees their level and below) |
-| Create | `POST /api/accounts/invitations/` | Admin+ (or manager for member-level invites) |
-| Retrieve | `GET /api/accounts/invitations/{id}/` | Sufficient role |
-| Update | `PUT/PATCH /api/accounts/invitations/{id}/` | Sufficient role |
-| Delete | `DELETE /api/accounts/invitations/{id}/` | Sufficient role |
-| Send email | `POST /api/accounts/invitations/{id}/send-email/` | Manager+ |
-| Choices | `GET /api/accounts/invitations/choices/` | Member of the org |
+| List | `GET /api/accounts/invitations/` | Admins see MANAGER+MEMBER; owners see all roles |
+| Create | `POST /api/accounts/invitations/` | Admin+ (owner for OWNER/ADMIN roles) |
+| Retrieve | `GET /api/accounts/invitations/{id}/` | Owner: any role; Admin: MANAGER+MEMBER only |
+| Update | `PUT/PATCH /api/accounts/invitations/{id}/` | Owner: any role; Admin: MANAGER+MEMBER only |
+| Delete | `DELETE /api/accounts/invitations/{id}/` | Owner: any role; Admin: MANAGER+MEMBER only |
+| Send email | `POST /api/accounts/invitations/{id}/send-email/` | Owner: any role; Admin: MANAGER+MEMBER only |
+| Choices | `GET /api/accounts/invitations/choices/` | Admins see MANAGER+MEMBER; owners see all roles |
 
 ### Send Email Cooldown
 

--- a/schema.yml
+++ b/schema.yml
@@ -3924,23 +3924,23 @@ components:
           type: integer
           nullable: true
           description: Organization to which the file belongs
-        original_name:
+        size:
+          type: integer
+          readOnly: true
+          description: Size of the file
+        download_name:
+          type: string
+          description: Return the name to download the file.
+          readOnly: true
+        content_type:
           type: string
           readOnly: true
-          description: Original name of the file
+          description: Content type of the file
         uuid:
           type: string
           format: uuid
           readOnly: true
           description: Unique identifier for the file
-        download_name:
-          type: string
-          description: Return the name to download the file.
-          readOnly: true
-        size:
-          type: integer
-          readOnly: true
-          description: Size of the file
         file_url:
           type: string
           nullable: true
@@ -3950,10 +3950,10 @@ components:
           format: date-time
           readOnly: true
           description: When the record was last updated
-        content_type:
+        original_name:
           type: string
           readOnly: true
-          description: Content type of the file
+          description: Original name of the file
     PatchedUserProfile:
       type: object
       description: Mixin for ModelSerializer to add user, member, and organization
@@ -4213,23 +4213,23 @@ components:
           type: integer
           nullable: true
           description: Organization to which the file belongs
-        original_name:
+        size:
+          type: integer
+          readOnly: true
+          description: Size of the file
+        download_name:
+          type: string
+          description: Return the name to download the file.
+          readOnly: true
+        content_type:
           type: string
           readOnly: true
-          description: Original name of the file
+          description: Content type of the file
         uuid:
           type: string
           format: uuid
           readOnly: true
           description: Unique identifier for the file
-        download_name:
-          type: string
-          description: Return the name to download the file.
-          readOnly: true
-        size:
-          type: integer
-          readOnly: true
-          description: Size of the file
         file_url:
           type: string
           nullable: true
@@ -4239,10 +4239,10 @@ components:
           format: date-time
           readOnly: true
           description: When the record was last updated
-        content_type:
+        original_name:
           type: string
           readOnly: true
-          description: Content type of the file
+          description: Original name of the file
       required:
       - content_type
       - download_name

--- a/schema.yml
+++ b/schema.yml
@@ -3924,27 +3924,23 @@ components:
           type: integer
           nullable: true
           description: Organization to which the file belongs
-        download_name:
-          type: string
-          description: Return the name to download the file.
-          readOnly: true
-        content_type:
-          type: string
-          readOnly: true
-          description: Content type of the file
         original_name:
           type: string
           readOnly: true
           description: Original name of the file
-        size:
-          type: integer
-          readOnly: true
-          description: Size of the file
         uuid:
           type: string
           format: uuid
           readOnly: true
           description: Unique identifier for the file
+        download_name:
+          type: string
+          description: Return the name to download the file.
+          readOnly: true
+        size:
+          type: integer
+          readOnly: true
+          description: Size of the file
         file_url:
           type: string
           nullable: true
@@ -3954,6 +3950,10 @@ components:
           format: date-time
           readOnly: true
           description: When the record was last updated
+        content_type:
+          type: string
+          readOnly: true
+          description: Content type of the file
     PatchedUserProfile:
       type: object
       description: Mixin for ModelSerializer to add user, member, and organization
@@ -4213,27 +4213,23 @@ components:
           type: integer
           nullable: true
           description: Organization to which the file belongs
-        download_name:
-          type: string
-          description: Return the name to download the file.
-          readOnly: true
-        content_type:
-          type: string
-          readOnly: true
-          description: Content type of the file
         original_name:
           type: string
           readOnly: true
           description: Original name of the file
-        size:
-          type: integer
-          readOnly: true
-          description: Size of the file
         uuid:
           type: string
           format: uuid
           readOnly: true
           description: Unique identifier for the file
+        download_name:
+          type: string
+          description: Return the name to download the file.
+          readOnly: true
+        size:
+          type: integer
+          readOnly: true
+          description: Size of the file
         file_url:
           type: string
           nullable: true
@@ -4243,6 +4239,10 @@ components:
           format: date-time
           readOnly: true
           description: When the record was last updated
+        content_type:
+          type: string
+          readOnly: true
+          description: Content type of the file
       required:
       - content_type
       - download_name

--- a/schema.yml
+++ b/schema.yml
@@ -3924,10 +3924,6 @@ components:
           type: integer
           nullable: true
           description: Organization to which the file belongs
-        size:
-          type: integer
-          readOnly: true
-          description: Size of the file
         download_name:
           type: string
           description: Return the name to download the file.
@@ -3936,24 +3932,28 @@ components:
           type: string
           readOnly: true
           description: Content type of the file
+        original_name:
+          type: string
+          readOnly: true
+          description: Original name of the file
+        size:
+          type: integer
+          readOnly: true
+          description: Size of the file
         uuid:
           type: string
           format: uuid
           readOnly: true
           description: Unique identifier for the file
-        file_url:
-          type: string
-          nullable: true
-          readOnly: true
         updated_at:
           type: string
           format: date-time
           readOnly: true
           description: When the record was last updated
-        original_name:
+        file_url:
           type: string
+          nullable: true
           readOnly: true
-          description: Original name of the file
     PatchedUserProfile:
       type: object
       description: Mixin for ModelSerializer to add user, member, and organization
@@ -4213,10 +4213,6 @@ components:
           type: integer
           nullable: true
           description: Organization to which the file belongs
-        size:
-          type: integer
-          readOnly: true
-          description: Size of the file
         download_name:
           type: string
           description: Return the name to download the file.
@@ -4225,24 +4221,28 @@ components:
           type: string
           readOnly: true
           description: Content type of the file
+        original_name:
+          type: string
+          readOnly: true
+          description: Original name of the file
+        size:
+          type: integer
+          readOnly: true
+          description: Size of the file
         uuid:
           type: string
           format: uuid
           readOnly: true
           description: Unique identifier for the file
-        file_url:
-          type: string
-          nullable: true
-          readOnly: true
         updated_at:
           type: string
           format: date-time
           readOnly: true
           description: When the record was last updated
-        original_name:
+        file_url:
           type: string
+          nullable: true
           readOnly: true
-          description: Original name of the file
       required:
       - content_type
       - download_name

--- a/schema.yml
+++ b/schema.yml
@@ -3924,32 +3924,32 @@ components:
           type: integer
           nullable: true
           description: Organization to which the file belongs
-        download_name:
-          type: string
-          description: Return the name to download the file.
-          readOnly: true
         content_type:
           type: string
           readOnly: true
           description: Content type of the file
+        download_name:
+          type: string
+          description: Return the name to download the file.
+          readOnly: true
         original_name:
           type: string
           readOnly: true
           description: Original name of the file
-        size:
-          type: integer
-          readOnly: true
-          description: Size of the file
-        uuid:
-          type: string
-          format: uuid
-          readOnly: true
-          description: Unique identifier for the file
         updated_at:
           type: string
           format: date-time
           readOnly: true
           description: When the record was last updated
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Unique identifier for the file
+        size:
+          type: integer
+          readOnly: true
+          description: Size of the file
         file_url:
           type: string
           nullable: true
@@ -4213,32 +4213,32 @@ components:
           type: integer
           nullable: true
           description: Organization to which the file belongs
-        download_name:
-          type: string
-          description: Return the name to download the file.
-          readOnly: true
         content_type:
           type: string
           readOnly: true
           description: Content type of the file
+        download_name:
+          type: string
+          description: Return the name to download the file.
+          readOnly: true
         original_name:
           type: string
           readOnly: true
           description: Original name of the file
-        size:
-          type: integer
-          readOnly: true
-          description: Size of the file
-        uuid:
-          type: string
-          format: uuid
-          readOnly: true
-          description: Unique identifier for the file
         updated_at:
           type: string
           format: date-time
           readOnly: true
           description: When the record was last updated
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Unique identifier for the file
+        size:
+          type: integer
+          readOnly: true
+          description: Size of the file
         file_url:
           type: string
           nullable: true

--- a/schema.yml
+++ b/schema.yml
@@ -44,6 +44,50 @@ paths:
         name: is_expired
         schema:
           type: boolean
+      - in: query
+        name: order_by
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - -email
+            - -expired_at
+            - -id
+            - -is_accepted
+            - -is_expired
+            - -last_email_sent_at
+            - -organization
+            - -role
+            - email
+            - expired_at
+            - id
+            - is_accepted
+            - is_expired
+            - last_email_sent_at
+            - organization
+            - role
+        description: |-
+          Ordering
+
+          * `email` - Email
+          * `-email` - Descending Email
+          * `expired_at` - Expired At
+          * `-expired_at` - Descending Expired At
+          * `id` - ID
+          * `-id` - Descending ID
+          * `is_accepted` - Is Accepted
+          * `-is_accepted` - Descending Is Accepted
+          * `is_expired` - Is Expired
+          * `-is_expired` - Descending Is Expired
+          * `last_email_sent_at` - Last Email Sent At
+          * `-last_email_sent_at` - Descending Last Email Sent At
+          * `organization` - Organization
+          * `-organization` - Descending Organization
+          * `role` - Role
+          * `-role` - Descending Role
+        explode: false
+        style: form
       - name: page
         required: false
         in: query
@@ -299,6 +343,58 @@ paths:
         name: nickname__icontains
         schema:
           type: string
+      - in: query
+        name: order_by
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - -created_at
+            - -created_by
+            - -id
+            - -is_active
+            - -last_login_at
+            - -nickname
+            - -organization
+            - -role
+            - -updated_at
+            - -updated_by
+            - created_at
+            - created_by
+            - id
+            - is_active
+            - last_login_at
+            - nickname
+            - organization
+            - role
+            - updated_at
+            - updated_by
+        description: |-
+          Ordering
+
+          * `created_at` - Created At
+          * `-created_at` - Descending Created At
+          * `created_by` - Created By
+          * `-created_by` - Descending Created By
+          * `id` - ID
+          * `-id` - Descending ID
+          * `is_active` - Is Active
+          * `-is_active` - Descending Is Active
+          * `last_login_at` - Last login at
+          * `-last_login_at` - Descending Last login at
+          * `nickname` - Nickname
+          * `-nickname` - Descending Nickname
+          * `organization` - Organization
+          * `-organization` - Descending Organization
+          * `role` - Role
+          * `-role` - Descending Role
+          * `updated_at` - Updated At
+          * `-updated_at` - Descending Updated At
+          * `updated_by` - Updated By
+          * `-updated_by` - Descending Updated By
+        explode: false
+        style: form
       - in: query
         name: organization
         schema:
@@ -620,6 +716,26 @@ paths:
           * `logo_dark` - Logo Dark
           * `logo_light` - Logo Light
       - in: query
+        name: order_by
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - -id
+            - -image_type
+            - id
+            - image_type
+        description: |-
+          Ordering
+
+          * `id` - ID
+          * `-id` - Descending ID
+          * `image_type` - Image type
+          * `-image_type` - Descending Image type
+        explode: false
+        style: form
+      - in: query
         name: organization
         schema:
           type: integer
@@ -808,6 +924,34 @@ paths:
         name: description__icontains
         schema:
           type: string
+      - in: query
+        name: order_by
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - -description
+            - -id
+            - -organization
+            - -website
+            - description
+            - id
+            - organization
+            - website
+        description: |-
+          Ordering
+
+          * `description` - Description
+          * `-description` - Descending Description
+          * `id` - ID
+          * `-id` - Descending ID
+          * `organization` - Organization
+          * `-organization` - Descending Organization
+          * `website` - Website
+          * `-website` - Descending Website
+        explode: false
+        style: form
       - name: page
         required: false
         in: query
@@ -995,6 +1139,30 @@ paths:
         name: name__icontains
         schema:
           type: string
+      - in: query
+        name: order_by
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - -id
+            - -name
+            - -slug
+            - id
+            - name
+            - slug
+        description: |-
+          Ordering
+
+          * `id` - ID
+          * `-id` - Descending ID
+          * `name` - Name
+          * `-name` - Descending Name
+          * `slug` - Slug
+          * `-slug` - Descending Slug
+        explode: false
+        style: form
       - name: page
         required: false
         in: query
@@ -1310,6 +1478,42 @@ paths:
         name: name__icontains
         schema:
           type: string
+      - in: query
+        name: order_by
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - -content_type
+            - -name
+            - -original_name
+            - -size
+            - -updated_at
+            - -uuid
+            - content_type
+            - name
+            - original_name
+            - size
+            - updated_at
+            - uuid
+        description: |-
+          Ordering
+
+          * `content_type` - Content Type
+          * `-content_type` - Descending Content Type
+          * `name` - Name
+          * `-name` - Descending Name
+          * `original_name` - Original Name
+          * `-original_name` - Descending Original Name
+          * `size` - Size
+          * `-size` - Descending Size
+          * `uuid` - UUID
+          * `-uuid` - Descending UUID
+          * `updated_at` - Updated At
+          * `-updated_at` - Descending Updated At
+        explode: false
+        style: form
       - in: query
         name: organization
         schema:
@@ -1864,6 +2068,54 @@ paths:
         name: member_full_name__icontains
         schema:
           type: string
+      - in: query
+        name: order_by
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - -created_at
+            - -created_by
+            - -id
+            - -is_active
+            - -member
+            - -role
+            - -team
+            - -updated_at
+            - -updated_by
+            - created_at
+            - created_by
+            - id
+            - is_active
+            - member
+            - role
+            - team
+            - updated_at
+            - updated_by
+        description: |-
+          Ordering
+
+          * `created_at` - Created At
+          * `-created_at` - Descending Created At
+          * `created_by` - Created By
+          * `-created_by` - Descending Created By
+          * `id` - ID
+          * `-id` - Descending ID
+          * `is_active` - Is Active
+          * `-is_active` - Descending Is Active
+          * `member` - Member
+          * `-member` - Descending Member
+          * `role` - Role
+          * `-role` - Descending Role
+          * `team` - Team
+          * `-team` - Descending Team
+          * `updated_at` - Updated At
+          * `-updated_at` - Descending Updated At
+          * `updated_by` - Updated By
+          * `-updated_by` - Descending Updated By
+        explode: false
+        style: form
       - name: page
         required: false
         in: query
@@ -2078,6 +2330,58 @@ paths:
         name: name__icontains
         schema:
           type: string
+      - in: query
+        name: order_by
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - -created_at
+            - -created_by
+            - -description
+            - -id
+            - -is_active
+            - -name
+            - -organization
+            - -slug
+            - -updated_at
+            - -updated_by
+            - created_at
+            - created_by
+            - description
+            - id
+            - is_active
+            - name
+            - organization
+            - slug
+            - updated_at
+            - updated_by
+        description: |-
+          Ordering
+
+          * `created_at` - Created At
+          * `-created_at` - Descending Created At
+          * `created_by` - Created By
+          * `-created_by` - Descending Created By
+          * `description` - Description
+          * `-description` - Descending Description
+          * `id` - ID
+          * `-id` - Descending ID
+          * `is_active` - Is Active
+          * `-is_active` - Descending Is Active
+          * `name` - Name
+          * `-name` - Descending Name
+          * `organization` - Organization
+          * `-organization` - Descending Organization
+          * `slug` - Slug
+          * `-slug` - Descending Slug
+          * `updated_at` - Updated At
+          * `-updated_at` - Descending Updated At
+          * `updated_by` - Updated By
+          * `-updated_by` - Descending Updated By
+        explode: false
+        style: form
       - in: query
         name: organization
         schema:
@@ -3620,36 +3924,36 @@ components:
           type: integer
           nullable: true
           description: Organization to which the file belongs
-        updated_at:
-          type: string
-          format: date-time
-          readOnly: true
-          description: When the record was last updated
-        original_name:
-          type: string
-          readOnly: true
-          description: Original name of the file
-        content_type:
-          type: string
-          readOnly: true
-          description: Content type of the file
-        size:
-          type: integer
-          readOnly: true
-          description: Size of the file
-        file_url:
-          type: string
-          nullable: true
-          readOnly: true
         download_name:
           type: string
           description: Return the name to download the file.
           readOnly: true
+        content_type:
+          type: string
+          readOnly: true
+          description: Content type of the file
+        original_name:
+          type: string
+          readOnly: true
+          description: Original name of the file
+        size:
+          type: integer
+          readOnly: true
+          description: Size of the file
         uuid:
           type: string
           format: uuid
           readOnly: true
           description: Unique identifier for the file
+        file_url:
+          type: string
+          nullable: true
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+          description: When the record was last updated
     PatchedUserProfile:
       type: object
       description: Mixin for ModelSerializer to add user, member, and organization
@@ -3909,36 +4213,36 @@ components:
           type: integer
           nullable: true
           description: Organization to which the file belongs
-        updated_at:
-          type: string
-          format: date-time
-          readOnly: true
-          description: When the record was last updated
-        original_name:
-          type: string
-          readOnly: true
-          description: Original name of the file
-        content_type:
-          type: string
-          readOnly: true
-          description: Content type of the file
-        size:
-          type: integer
-          readOnly: true
-          description: Size of the file
-        file_url:
-          type: string
-          nullable: true
-          readOnly: true
         download_name:
           type: string
           description: Return the name to download the file.
           readOnly: true
+        content_type:
+          type: string
+          readOnly: true
+          description: Content type of the file
+        original_name:
+          type: string
+          readOnly: true
+          description: Original name of the file
+        size:
+          type: integer
+          readOnly: true
+          description: Size of the file
         uuid:
           type: string
           format: uuid
           readOnly: true
           description: Unique identifier for the file
+        file_url:
+          type: string
+          nullable: true
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+          description: When the record was last updated
       required:
       - content_type
       - download_name
@@ -4122,11 +4426,17 @@ components:
           type: string
           description: Return the name to download the file.
           readOnly: true
+        organization:
+          type: integer
+          readOnly: true
+          nullable: true
+          description: Organization to which the file belongs
       required:
       - content_type
       - download_name
       - file
       - file_url
+      - organization
       - original_name
       - size
       - uuid


### PR DESCRIPTION
## Changes

### Auto Orderable Filter
- Add `ModelSerializerFieldsMixin` with `orderable_fields_choices` generation
- Add `ModelViewSetMetaclass` that auto-injects `OrderingFilter` into filtersets
- Enable `?order_by=` on all 8 list endpoints (Organization, Member, Invitation,
  StoredFile, OrganizationImage, OrganizationProfile, Team, TeamMember)
- 50 tests covering unit (mixin + metaclass) and integration (ascending,
  descending, invalid field, combined filters)

### Infrastructure
- Increase throttle rates: anonymous 100→1000/h, authenticated 1000→10000/h
- Add logging to custom exception handler for better debug visibility

### Bug Fix
- Fix `InvitationPermission.has_object_permission`: admin can only see
  MANAGER/MEMBER invites (not ADMIN/OWNER)
- Update tests and documentation to reflect corrected behavior